### PR TITLE
Phase 0: bug fixes for and3s dispatch (refs #36)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^Benchmarks\.html$
 ^Moving-from-Rcpp-to-C\.md$
 ^CRAN-SUBMISSION$
+^\.claude$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hutilscpp
 Title: Miscellaneous Functions in C++
-Version: 0.10.11
+Version: 0.10.12
 Authors@R: 
     c(person(given = "Hugh",
            family = "Parsonage",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+## hutilscpp 0.10.12
+
+### Bug fixes
+
+- `vand2s_II` M==2 fast path now handles `y0 == y1` for all three between
+  operators. Previously only `%between%` was handled; `%(between)%` and
+  `%]between[%` fell through to the general `y0 < y1` code, which gave
+  wrong answers due to unsigned wrap-around in `betweeniiuu(x, y0+1, y0-1)`
+  (#47).
+- `and3s(...)` now honours `type = "raw"` / `type = "which"` when the
+  C dispatcher returns NULL and execution falls back to base `&`.
+  Previously an inner `return()` short-circuited the type conversion (#40).
+- `vand2s_RI`/`vand2s_RD` no longer overwrite the running AND-chain mask
+  when `%notin%` / `!=` is called against a scalar that is out of raw
+  range (or, for `RD`, a non-integer or NaN). Always-true predicates are
+  now correctly a no-op (#38, #39).
+- Add missing `break;` after `OP_NI` in the M==N branches of
+  `vand2s_RR` / `vand2s_RI` / `vand2s_RD`. Latent (the fall-through was
+  semantically idempotent), but pinned for future refactors (#37).
+
 ## hutilscpp 0.10.11
 
 ### Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,13 @@
   `vand2s_RR` / `vand2s_RI` / `vand2s_RD`. Latent (the fall-through was
   semantically idempotent), but pinned for future refactors (#37).
 
+### Documentation
+
+- `?and3s` / `?or3s` now document the package's two-valued mask
+  convention for `NA` / `NaN`-valued comparisons (treated as `FALSE`
+  in the mask, except for `!=` / `%notin%` against `NaN` which remain
+  `TRUE`). This is a divergence from base R, which propagates `NA`.
+
 ## hutilscpp 0.10.11
 
 ### Bug fixes

--- a/R/logical3s.R
+++ b/R/logical3s.R
@@ -125,7 +125,9 @@ and3s <- function(exprA, exprB = NULL, exprC = NULL,
 
   if (is.null(ans)) {
     message("Falling back to `&`")
-    ans <- Reduce("&", list(exprA, exprB %||% TRUE, exprC %||% TRUE, ...))
+    args <- list(exprA, exprB %||% TRUE, exprC %||% TRUE, ...)
+    args <- lapply(args, function(a) if (is.raw(a)) raw2lgl(a, nThread = nThread) else a)
+    ans <- Reduce("&", args)
     return(switch(type,
                   raw = lgl2raw(ans),
                   logical = ans,
@@ -244,8 +246,9 @@ or3s <- function(exprA, exprB = NULL, exprC = NULL,
   # nocov start
   if (is.null(ans)) {
     message("Falling back to `|`")
-    # fall back
-    return(Reduce("|", list(exprA, exprB %||% FALSE, exprC %||% FALSE, ...)))
+    args <- list(exprA, exprB %||% FALSE, exprC %||% FALSE, ...)
+    args <- lapply(args, function(a) if (is.raw(a)) raw2lgl(a, nThread = nThread) else a)
+    return(Reduce("|", args))
   }
   # nocov end
 

--- a/R/logical3s.R
+++ b/R/logical3s.R
@@ -32,7 +32,17 @@
 #' it is considered \code{TRUE} for \code{and3s} and \code{FALSE} for \code{or3s};
 #' in other words only the results of the other expressions count towards the result.
 #'
+#' @section Note on NA / NaN:
 #'
+#' The fast path uses a two-valued mask, so an \code{NA}-valued comparison
+#' is treated as \code{FALSE} in the mask rather than propagated. The most
+#' common case is a \code{NaN} numeric scalar against a \code{raw} vector:
+#' under base R, \code{as.raw(5) > NaN} is \code{NA}; under \code{and3s}
+#' / \code{or3s} on long inputs, the corresponding mask entry is
+#' \code{FALSE} (always-true predicates such as \code{!=} / \code{\%notin\%}
+#' against \code{NaN} remain \code{TRUE}). For filter-mask use this is
+#' usually the desired behaviour; to obtain base-R semantics, evaluate
+#' the predicates separately and combine with \code{&} / \code{|}.
 #'
 NULL
 

--- a/R/logical3s.R
+++ b/R/logical3s.R
@@ -125,8 +125,7 @@ and3s <- function(exprA, exprB = NULL, exprC = NULL,
 
   if (is.null(ans)) {
     message("Falling back to `&`")
-    # fall back
-    ans <- return(Reduce("&", list(exprA, exprB %||% TRUE, exprC %||% TRUE, ...)))
+    ans <- Reduce("&", list(exprA, exprB %||% TRUE, exprC %||% TRUE, ...))
     return(switch(type,
                   raw = lgl2raw(ans),
                   logical = ans,

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -312,6 +312,26 @@ expect_equal(and3s(xdb != 5, xdb %(between)% c(2L, 8L)),
 expect_equal(and3s(xdb == 5, xdb %]between[% c(3L, 7L)),
              (xdb == 5) & (xdb <= 3 | xdb >= 7))
 
+# Regression for #38: vand2s_RI/RD M==1 must not clobber the AND-chain when
+# the scalar is out of raw range. OP_NI/OP_NE with out-of-range scalar is
+# always-true → no-op; previously memset to 1 wiped earlier predicates.
+rr_chain <- as.raw(rep_len(c(0L, 5L), nb))
+expect_equal(and3s(rr_chain == as.raw(5), rr_chain %notin% c(-1L)),
+             (rr_chain == as.raw(5)) & (rep_len(TRUE, nb)))
+expect_equal(and3s(rr_chain == as.raw(5), rr_chain %notin% c(-1)),
+             (rr_chain == as.raw(5)) & (rep_len(TRUE, nb)))
+expect_equal(and3s(rr_chain == as.raw(5), rr_chain != 256L),
+             (rr_chain == as.raw(5)) & (rep_len(TRUE, nb)))
+# Always-false direction (OP_IN with out-of-range) should AND with 0.
+expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(-1L))))
+
+# Regression for #39: vand2s_RD M==1 must not truncate non-integer scalars.
+# `raw_x %in% c(5.5)` should be all FALSE; `%notin% c(5.5)` should be all TRUE.
+expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(5.5))))
+expect_equal(and3s(rr_chain == as.raw(5), rr_chain %notin% c(5.5)),
+             rr_chain == as.raw(5))
+expect_false(any(and3s(rr_chain != as.raw(0), rr_chain == 5.5)))
+
 # Regression for #37: missing `break;` after OP_NI in vand2s_R{R,I,D} M==N
 # branch — silently fell through to OP_NE. Currently latent (compatible
 # semantics), but pin the contract so the next refactor doesn't trip.

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -331,13 +331,13 @@ expect_equal(and3s(ib %]between[% c(5L, 5L), ib != 0L),
 # branch in vand2s and forces a NULL return from `Cands`.
 ix_fb <- 1:nb
 ry_fb <- as.raw(rep_len(c(0L, 1L), nb))
-out_l <- suppressMessages(and3s(ix_fb == ry_fb, type = "logical"))
-expect_true(is.logical(out_l))
-out_r <- suppressMessages(and3s(ix_fb == ry_fb, type = "raw"))
-expect_true(is.raw(out_r))
-out_w <- suppressMessages(and3s(ix_fb == ry_fb, type = "which"))
-expect_true(is.integer(out_w))
-expect_equal(out_w, which(ix_fb == ry_fb))
+ref_fb <- ix_fb == ry_fb
+expect_equal(suppressMessages(and3s(ix_fb == ry_fb, type = "logical")),
+             ref_fb)
+expect_equal(suppressMessages(and3s(ix_fb == ry_fb, type = "raw")),
+             hutilscpp:::lgl2raw(ref_fb))
+expect_equal(suppressMessages(and3s(ix_fb == ry_fb, type = "which")),
+             which(ref_fb))
 
 # Regression for #38: vand2s_RI/RD M==1 must not clobber the AND-chain when
 # the scalar is out of raw range. OP_NI/OP_NE with out-of-range scalar is
@@ -383,6 +383,17 @@ expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5L)),
 expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5.5)),
              hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) > 5.5))
 
+# Documented divergence from base R (see ?and3s "Note on NA / NaN"):
+# NaN comparisons evaluate to FALSE in the mask (TRUE for `!=`/`%notin%`),
+# rather than propagating NA. Pin this so future changes don't regress
+# the on-CRAN convention.
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain > NaN),
+             logical(nb))
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain == NaN),
+             logical(nb))
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain != NaN),
+             rr_chain != as.raw(0))
+
 # Regression for #39: vand2s_RD M==1 must not truncate non-integer scalars.
 # `raw_x %in% c(5.5)` should be all FALSE; `%notin% c(5.5)` should be all TRUE.
 expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(5.5))))
@@ -395,20 +406,22 @@ expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > 5.5)),
 expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain <= 5.5)),
              (rr_chain != as.raw(0)) & (as.integer(rr_chain) <= 5.5))
 
-# Regression for #37: missing `break;` after OP_NI in vand2s_R{R,I,D} M==N
-# branch — silently fell through to OP_NE. Currently latent (compatible
-# semantics), but pin the contract so the next refactor doesn't trip.
-rr_ni  <- as.raw(rep_len(c(0L, 5L, 10L), nb))
-rr_tbl <- as.raw(c(5L, 10L))                    # M=2 != N
-i_tbl  <- as.integer(rr_tbl)
-d_tbl  <- as.numeric(rr_tbl)
-# The wrapper rewrites `%notin% short_table` via fnotinp before reaching the
-# C dispatcher, so to exercise the M==N raw fall-through we need a vector
-# call that lands directly on vand2s_R*. Equality with M==N suffices to
-# pin the dispatch invariant.
-rr_eq  <- as.raw(rep_len(c(0L, 5L), nb))
-expect_equal(and3s(rr_eq != as.raw(0), rr_eq == rr_eq),
-             (rr_eq != as.raw(0)) & (rr_eq == rr_eq))
+# Regression for #37: OP_NI in `vand2s_R{R,I,D}` M==N branches lacked a
+# `break;` and fell through to OP_NE. The fall-through happens to be
+# semantically idempotent (`x notin y[*]` implies `x != y[i]`, so the
+# extra `&=` is always with TRUE where the mask is still TRUE), so no
+# input value distinguishes pre-fix from post-fix output. These tests
+# pin the *path*: any future change to the OP_NE body that breaks the
+# implication would now surface here. The path is reachable because
+# the R wrapper preprocesses %notin% via `fnotinp` only for non-raw
+# `xx1` (R/logical3s.R:91), so raw %notin% raw lands on vand2s_RR.
+rr_x_ni <- as.raw(rep_len(c(0L, 5L, 10L), nb))
+rr_y_ni <- as.raw(rep_len(c(5L, 10L), nb))      # length == nb (M == N)
+expect_equal(and3s(rr_x_ni != as.raw(0), rr_x_ni %notin% rr_y_ni),
+             (rr_x_ni != as.raw(0)) & !(rr_x_ni %in% rr_y_ni))
+# Reverse order to verify position invariance.
+expect_equal(and3s(rr_x_ni %notin% rr_y_ni, rr_x_ni != as.raw(0)),
+             (rr_x_ni != as.raw(0)) & !(rr_x_ni %in% rr_y_ni))
 
 rr <- raw(1e5)
 expect_true(all(and3s(rr == rr)))

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -352,12 +352,30 @@ expect_equal(and3s(rr_chain == as.raw(5), rr_chain != 256L),
 # Always-false direction (OP_IN with out-of-range) should AND with 0.
 expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(-1L))))
 
+# Regression for #38 (review follow-up): out-of-range raw order comparisons
+# must not silently no-op. The original out-of-range short-circuit covered
+# IN/EQ/NI/NE only; for order ops the kernel must signal err so the R
+# wrapper falls back to base `&`, matching base R semantics.
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > 256L)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) > 256L))
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > -1L)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) > -1L))
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain < -1L)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) < -1L))
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain <= 256L)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) <= 256L))
+
 # Regression for #39: vand2s_RD M==1 must not truncate non-integer scalars.
 # `raw_x %in% c(5.5)` should be all FALSE; `%notin% c(5.5)` should be all TRUE.
 expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(5.5))))
 expect_equal(and3s(rr_chain == as.raw(5), rr_chain %notin% c(5.5)),
              rr_chain == as.raw(5))
 expect_false(any(and3s(rr_chain != as.raw(0), rr_chain == 5.5)))
+# Order ops with non-integer RHS must fall back, not no-op.
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > 5.5)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) > 5.5))
+expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain <= 5.5)),
+             (rr_chain != as.raw(0)) & (as.integer(rr_chain) <= 5.5))
 
 # Regression for #37: missing `break;` after OP_NI in vand2s_R{R,I,D} M==N
 # branch — silently fell through to OP_NE. Currently latent (compatible

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -312,6 +312,21 @@ expect_equal(and3s(xdb != 5, xdb %(between)% c(2L, 8L)),
 expect_equal(and3s(xdb == 5, xdb %]between[% c(3L, 7L)),
              (xdb == 5) & (xdb <= 3 | xdb >= 7))
 
+# Regression for #37: missing `break;` after OP_NI in vand2s_R{R,I,D} M==N
+# branch — silently fell through to OP_NE. Currently latent (compatible
+# semantics), but pin the contract so the next refactor doesn't trip.
+rr_ni  <- as.raw(rep_len(c(0L, 5L, 10L), nb))
+rr_tbl <- as.raw(c(5L, 10L))                    # M=2 != N
+i_tbl  <- as.integer(rr_tbl)
+d_tbl  <- as.numeric(rr_tbl)
+# The wrapper rewrites `%notin% short_table` via fnotinp before reaching the
+# C dispatcher, so to exercise the M==N raw fall-through we need a vector
+# call that lands directly on vand2s_R*. Equality with M==N suffices to
+# pin the dispatch invariant.
+rr_eq  <- as.raw(rep_len(c(0L, 5L), nb))
+expect_equal(and3s(rr_eq != as.raw(0), rr_eq == rr_eq),
+             (rr_eq != as.raw(0)) & (rr_eq == rr_eq))
+
 rr <- raw(1e5)
 expect_true(all(and3s(rr == rr)))
 expect_true(all(and3s(rr == 0L)))

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -291,7 +291,7 @@ expect_equal( or3s(xx == 2, bb >= 5, xx %in% bb), ((xx %in% bb) | (xx == 2 | bb 
 
 # Regression: AND-chain accumulator must not be overwritten by the
 # `uc_betweenidd` y0i == y1i fast path. Constructed so the first term
-# is FALSE exactly where the between term is TRUE — an overwrite would
+# is FALSE exactly where the between term is TRUE -- an overwrite would
 # flip those positions to TRUE.
 nb <- 5e3
 ib <- rep_len(1:10, nb)
@@ -341,7 +341,7 @@ expect_equal(suppressMessages(and3s(ix_fb == ry_fb, type = "which")),
 
 # Regression for #38: vand2s_RI/RD M==1 must not clobber the AND-chain when
 # the scalar is out of raw range. OP_NI/OP_NE with out-of-range scalar is
-# always-true → no-op; previously memset to 1 wiped earlier predicates.
+# always-true -> no-op; previously memset to 1 wiped earlier predicates.
 rr_chain <- as.raw(rep_len(c(0L, 5L), nb))
 expect_equal(and3s(rr_chain == as.raw(5), rr_chain %notin% c(-1L)),
              (rr_chain == as.raw(5)) & (rep_len(TRUE, nb)))
@@ -353,7 +353,7 @@ expect_equal(and3s(rr_chain == as.raw(5), rr_chain != 256L),
 expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(-1L))))
 
 # Regression for #38 (review follow-up): out-of-range raw order comparisons
-# are now handled in C — every supported predicate has a constant truth
+# are now handled in C -- every supported predicate has a constant truth
 # value when y is out of [0, 255], so apply directly rather than punt to
 # fallback (which previously errored on raw-mask exprA inputs).
 expect_equal(and3s(rr_chain != as.raw(0), rr_chain > 256L),
@@ -377,7 +377,7 @@ expect_equal(and3s(mask_raw, rr_chain < -1L),
 # Regression: raw fallback path. Order ops with in-range integer RHS
 # aren't implemented in vand2s_RI's M==1 switch, so they set *err and
 # the R wrapper falls back. The fallback must coerce raw arguments to
-# logical before `Reduce("&", ...)` — base `&` rejects raw + logical.
+# logical before `Reduce("&", ...)` -- base `&` rejects raw + logical.
 expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5L)),
              hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) > 5L))
 expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5.5)),

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -312,6 +312,18 @@ expect_equal(and3s(xdb != 5, xdb %(between)% c(2L, 8L)),
 expect_equal(and3s(xdb == 5, xdb %]between[% c(3L, 7L)),
              (xdb == 5) & (xdb <= 3 | xdb >= 7))
 
+# Regression for #47: vand2s_II M==2 OP_BO/OP_BC with y0==y1.
+# The y0==y1 branch was only handled for OP_BW; OP_BO and OP_BC fell
+# through to the general y0<y1 code which gave wrong answers due to
+# unsigned wrap-around in `betweeniiuu(x, y0+1, y0-1)`.
+expect_equal(and3s(ib != 0L, ib %(between)% c(5L, 5L)),
+             (ib != 0L) & (ib > 5L & ib < 5L))
+expect_equal(and3s(ib != 0L, ib %]between[% c(5L, 5L)),
+             (ib != 0L) & (ib <= 5L | ib >= 5L))
+# y0==y1 in first position too (not just second)
+expect_equal(and3s(ib %]between[% c(5L, 5L), ib != 0L),
+             (ib %]between[% c(5L, 5L)) & (ib != 0L))
+
 # Regression for #40: when the C dispatcher returns NULL and we fall back
 # to base `&`, the user's `type` argument must be honoured. An inner
 # `return()` was previously short-circuiting before the type conversion.

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -312,6 +312,21 @@ expect_equal(and3s(xdb != 5, xdb %(between)% c(2L, 8L)),
 expect_equal(and3s(xdb == 5, xdb %]between[% c(3L, 7L)),
              (xdb == 5) & (xdb <= 3 | xdb >= 7))
 
+# Regression for #40: when the C dispatcher returns NULL and we fall back
+# to base `&`, the user's `type` argument must be honoured. An inner
+# `return()` was previously short-circuiting before the type conversion.
+# Trigger via INTSXP x with RAWSXP y, which lands on the unsupported-y
+# branch in vand2s and forces a NULL return from `Cands`.
+ix_fb <- 1:nb
+ry_fb <- as.raw(rep_len(c(0L, 1L), nb))
+out_l <- suppressMessages(and3s(ix_fb == ry_fb, type = "logical"))
+expect_true(is.logical(out_l))
+out_r <- suppressMessages(and3s(ix_fb == ry_fb, type = "raw"))
+expect_true(is.raw(out_r))
+out_w <- suppressMessages(and3s(ix_fb == ry_fb, type = "which"))
+expect_true(is.integer(out_w))
+expect_equal(out_w, which(ix_fb == ry_fb))
+
 # Regression for #38: vand2s_RI/RD M==1 must not clobber the AND-chain when
 # the scalar is out of raw range. OP_NI/OP_NE with out-of-range scalar is
 # always-true → no-op; previously memset to 1 wiped earlier predicates.

--- a/inst/tinytest/test-and3s.R
+++ b/inst/tinytest/test-and3s.R
@@ -353,17 +353,35 @@ expect_equal(and3s(rr_chain == as.raw(5), rr_chain != 256L),
 expect_false(any(and3s(rr_chain == as.raw(5), rr_chain %in% c(-1L))))
 
 # Regression for #38 (review follow-up): out-of-range raw order comparisons
-# must not silently no-op. The original out-of-range short-circuit covered
-# IN/EQ/NI/NE only; for order ops the kernel must signal err so the R
-# wrapper falls back to base `&`, matching base R semantics.
-expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > 256L)),
+# are now handled in C — every supported predicate has a constant truth
+# value when y is out of [0, 255], so apply directly rather than punt to
+# fallback (which previously errored on raw-mask exprA inputs).
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain > 256L),
              (rr_chain != as.raw(0)) & (as.integer(rr_chain) > 256L))
-expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain > -1L)),
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain > -1L),
              (rr_chain != as.raw(0)) & (as.integer(rr_chain) > -1L))
-expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain < -1L)),
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain < -1L),
              (rr_chain != as.raw(0)) & (as.integer(rr_chain) < -1L))
-expect_equal(suppressMessages(and3s(rr_chain != as.raw(0), rr_chain <= 256L)),
+expect_equal(and3s(rr_chain != as.raw(0), rr_chain <= 256L),
              (rr_chain != as.raw(0)) & (as.integer(rr_chain) <= 256L))
+
+# Regression: precomputed raw mask + raw order op with out-of-range RHS
+# (the reviewer's example). C-side handling means no fallback is needed
+# here; the result must match base R after `raw2lgl` on the mask.
+mask_raw <- and3s(rr_chain != as.raw(0), type = "raw")
+expect_equal(and3s(mask_raw, rr_chain > 256L),
+             hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) > 256L))
+expect_equal(and3s(mask_raw, rr_chain < -1L),
+             hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) < -1L))
+
+# Regression: raw fallback path. Order ops with in-range integer RHS
+# aren't implemented in vand2s_RI's M==1 switch, so they set *err and
+# the R wrapper falls back. The fallback must coerce raw arguments to
+# logical before `Reduce("&", ...)` — base `&` rejects raw + logical.
+expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5L)),
+             hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) > 5L))
+expect_equal(suppressMessages(and3s(mask_raw, rr_chain > 5.5)),
+             hutilscpp:::raw2lgl(mask_raw) & (as.integer(rr_chain) > 5.5))
 
 # Regression for #39: vand2s_RD M==1 must not truncate non-integer scalars.
 # `raw_x %in% c(5.5)` should be all FALSE; `%notin% c(5.5)` should be all TRUE.

--- a/man/logical3s.Rd
+++ b/man/logical3s.Rd
@@ -57,3 +57,17 @@ Performance is high when the expressions are long (i.e. over 10M elements)
 and in particular when they are of the form \code{lhs <op> rhs} for binary
 \code{<op>}.
 }
+\section{Note on NA / NaN}{
+
+
+The fast path uses a two-valued mask, so an \code{NA}-valued comparison
+is treated as \code{FALSE} in the mask rather than propagated. The most
+common case is a \code{NaN} numeric scalar against a \code{raw} vector:
+under base R, \code{as.raw(5) > NaN} is \code{NA}; under \code{and3s}
+/ \code{or3s} on long inputs, the corresponding mask entry is
+\code{FALSE} (always-true predicates such as \code{!=} / \code{\%notin\%}
+against \code{NaN} remain \code{TRUE}). For filter-mask use this is
+usually the desired behaviour; to obtain base-R semantics, evaluate
+the predicates separately and combine with \code{&} / \code{|}.
+}
+

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -741,19 +741,26 @@ static void vand2s_RI(unsigned char * ansp, const int o,
                       int * err) {
   if (M == 1) {
     if (y[0] < 0 || y[0] > 255) {
-      // No raw equals an out-of-range scalar.
-      // OP_IN/OP_EQ: predicate is always-false, AND with 0.
-      // OP_NI/OP_NE: predicate is always-true, no-op against the running mask.
-      // Order ops are not handled in this kernel; signal err so the R
-      // wrapper falls back to base `&` rather than silently no-op'ing.
+      // Raw x is in [0, 255]; for an out-of-range scalar y the result of
+      // every supported predicate is constant. Apply directly so the
+      // call doesn't need to drop out to the R fallback.
+      const bool y_lt_zero = y[0] < 0;
       switch(o) {
       case OP_IN:
       case OP_EQ:
-        memset(ansp, 0, N);
+        memset(ansp, 0, N);              // never equal
         break;
       case OP_NI:
       case OP_NE:
-        break;
+        break;                           // always not equal: no-op
+      case OP_GT:
+      case OP_GE:
+        if (!y_lt_zero) memset(ansp, 0, N);  // x >= 0; if y > 255, never
+        break;                                // if y < 0, always: no-op
+      case OP_LT:
+      case OP_LE:
+        if (y_lt_zero) memset(ansp, 0, N);   // x >= 0; if y < 0, never
+        break;                                // if y > 255, always: no-op
       default:
         *err = AND3_UNSUPPORTED_TYPEY;
       }
@@ -825,12 +832,14 @@ static void vand2s_RD(unsigned char * ansp, const int o,
                       int nThread,
                       int * err) {
   if (M == 1) {
-    if (ISNAN(y[0]) || y[0] < 0 || y[0] > 255 || y[0] != (int)y[0]) {
-      // No raw equals NaN, an out-of-range, or a non-integer scalar.
-      // OP_IN/OP_EQ: always-false → AND with 0.
-      // OP_NI/OP_NE: always-true → no-op.
-      // Order ops are not handled in this kernel; signal err so the R
-      // wrapper falls back to base `&` rather than silently no-op'ing.
+    // Three short-circuit shapes for the M==1 RHS:
+    //   (a) NaN or non-integer in [0, 255]: ==/!= are constant; order ops
+    //       depend on x and need fallback (raw NaN comparisons return NA
+    //       in base R, which the 2-valued mask can't represent).
+    //   (b) Out-of-range integer: every supported predicate is constant.
+    //   (c) Integer in [0, 255]: dispatch as before; order ops set *err
+    //       and rely on fallback (this kernel only implements ==/!=).
+    if (ISNAN(y[0]) || (y[0] >= 0 && y[0] <= 255 && y[0] != (int)y[0])) {
       switch(o) {
       case OP_IN:
       case OP_EQ:
@@ -838,6 +847,29 @@ static void vand2s_RD(unsigned char * ansp, const int o,
         break;
       case OP_NI:
       case OP_NE:
+        break;
+      default:
+        *err = AND3_UNSUPPORTED_TYPEY;
+      }
+      return;
+    }
+    if (y[0] < 0 || y[0] > 255) {
+      const bool y_lt_zero = y[0] < 0;
+      switch(o) {
+      case OP_IN:
+      case OP_EQ:
+        memset(ansp, 0, N);
+        break;
+      case OP_NI:
+      case OP_NE:
+        break;
+      case OP_GT:
+      case OP_GE:
+        if (!y_lt_zero) memset(ansp, 0, N);
+        break;
+      case OP_LT:
+      case OP_LE:
+        if (y_lt_zero) memset(ansp, 0, N);
         break;
       default:
         *err = AND3_UNSUPPORTED_TYPEY;

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -729,7 +729,12 @@ static void vand2s_RI(unsigned char * ansp, const int o,
                       int * err) {
   if (M == 1) {
     if (y[0] < 0 || y[0] > 255) {
-      memset(ansp, o == OP_NI || o == OP_NE, N);
+      // No raw equals an out-of-range scalar.
+      // OP_IN/OP_EQ: predicate is always-false, AND with 0.
+      // OP_NI/OP_NE: predicate is always-true, no-op against the running mask.
+      if (o == OP_IN || o == OP_EQ) {
+        memset(ansp, 0, N);
+      }
       return;
     }
 
@@ -798,8 +803,13 @@ static void vand2s_RD(unsigned char * ansp, const int o,
                       int nThread,
                       int * err) {
   if (M == 1) {
-    if (ISNAN(y[0]) || y[0] < 0 || y[0] > 255) {
-      memset(ansp, o == OP_NI || o == OP_NE, N);
+    if (ISNAN(y[0]) || y[0] < 0 || y[0] > 255 || y[0] != (int)y[0]) {
+      // No raw equals NaN, an out-of-range, or a non-integer scalar.
+      // OP_IN/OP_EQ: always-false → AND with 0.
+      // OP_NI/OP_NE: always-true → no-op.
+      if (o == OP_IN || o == OP_EQ) {
+        memset(ansp, 0, N);
+      }
       return;
     }
     const unsigned char y0 = y[0];

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -171,12 +171,24 @@ static void vand2s_II(unsigned char * ansp,
       FORLOOP(ansp[i] = 0;)
       return;
     }
+    if (y0 == y1) {
+      switch(o) {
+      case OP_BW:
+        // x in [y0, y0] iff x == y0
+        FORLOOP_ands(==, y0)
+        break;
+      case OP_BO:
+        // x in (y0, y0) is always false
+        FORLOOP(ansp[i] = 0;)
+        break;
+      case OP_BC:
+        // x <= y0 || x >= y0 is always true; no-op against the AND mask
+        break;
+      }
+      return;
+    }
     switch(o) {
     case OP_BW: {
-      if (y0 == y1) {
-      FORLOOP_ands(==, y0)
-      break;
-    }
       // y0 < y1
       if (y0 == 0) {
 #if defined _OPENMP && _OPENMP >= 201511

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -694,6 +694,7 @@ static void vand2s_RR(unsigned char * ansp, const int o,
           }
         }
       })
+      break;
     case OP_NE:
       FORLOOP({ansp[i] &= x[i] != y[i];})
       break;
@@ -763,6 +764,7 @@ static void vand2s_RI(unsigned char * ansp, const int o,
           }
         }
       })
+      break;
     case OP_NE:
       FORLOOP({ansp[i] &= x[i] != y[i];})
       break;
@@ -831,6 +833,7 @@ static void vand2s_RD(unsigned char * ansp, const int o,
           }
         }
       })
+      break;
     case OP_NE:
       FORLOOP({ansp[i] &= x[i] != y[i];})
       break;

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -832,14 +832,23 @@ static void vand2s_RD(unsigned char * ansp, const int o,
                       int nThread,
                       int * err) {
   if (M == 1) {
-    // Three short-circuit shapes for the M==1 RHS:
-    //   (a) NaN or non-integer in [0, 255]: ==/!= are constant; order ops
-    //       depend on x and need fallback (raw NaN comparisons return NA
-    //       in base R, which the 2-valued mask can't represent).
-    //   (b) Out-of-range integer: every supported predicate is constant.
-    //   (c) Integer in [0, 255]: dispatch as before; order ops set *err
-    //       and rely on fallback (this kernel only implements ==/!=).
-    if (ISNAN(y[0]) || (y[0] >= 0 && y[0] <= 255 && y[0] != (int)y[0])) {
+    if (ISNAN(y[0])) {
+      // Package convention (NA -> FALSE in mask): NaN comparisons
+      // evaluate to FALSE for every op except `!=` / `%notin%` which are
+      // TRUE. Documented divergence from base R, which propagates NA.
+      // See ?and3s "Note on NA / NaN".
+      switch(o) {
+      case OP_NI:
+      case OP_NE:
+        break;
+      default:
+        memset(ansp, 0, N);
+      }
+      return;
+    }
+    if (y[0] >= 0 && y[0] <= 255 && y[0] != (int)y[0]) {
+      // Non-integer in [0, 255]: == / != are constant; order ops depend
+      // on x (raw is integer-valued) and need fallback.
       switch(o) {
       case OP_IN:
       case OP_EQ:

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -744,8 +744,18 @@ static void vand2s_RI(unsigned char * ansp, const int o,
       // No raw equals an out-of-range scalar.
       // OP_IN/OP_EQ: predicate is always-false, AND with 0.
       // OP_NI/OP_NE: predicate is always-true, no-op against the running mask.
-      if (o == OP_IN || o == OP_EQ) {
+      // Order ops are not handled in this kernel; signal err so the R
+      // wrapper falls back to base `&` rather than silently no-op'ing.
+      switch(o) {
+      case OP_IN:
+      case OP_EQ:
         memset(ansp, 0, N);
+        break;
+      case OP_NI:
+      case OP_NE:
+        break;
+      default:
+        *err = AND3_UNSUPPORTED_TYPEY;
       }
       return;
     }
@@ -819,8 +829,18 @@ static void vand2s_RD(unsigned char * ansp, const int o,
       // No raw equals NaN, an out-of-range, or a non-integer scalar.
       // OP_IN/OP_EQ: always-false → AND with 0.
       // OP_NI/OP_NE: always-true → no-op.
-      if (o == OP_IN || o == OP_EQ) {
+      // Order ops are not handled in this kernel; signal err so the R
+      // wrapper falls back to base `&` rather than silently no-op'ing.
+      switch(o) {
+      case OP_IN:
+      case OP_EQ:
         memset(ansp, 0, N);
+        break;
+      case OP_NI:
+      case OP_NE:
+        break;
+      default:
+        *err = AND3_UNSUPPORTED_TYPEY;
       }
       return;
     }


### PR DESCRIPTION
Phase 0 of the refactor epic in #36 — six concrete bug fixes (five from initial review, one found during the audit), plus documentation of an existing on-CRAN divergence from base R that came up while iterating.

## Fixes

| Issue | Summary |
|------:|---------|
| #37 | Missing `break;` after OP_NI in `vand2s_R{R,I,D}` M==N branches (latent fall-through to OP_NE; pinned for future refactors). |
| #38 | `vand2s_RI` / `vand2s_RD` M==1 with out-of-range scalar: every supported op now gets the right action (constant-true / constant-false) directly in C — including the order ops, which previously either clobbered the AND-chain mask (CRAN) or no-op'd it (a regression in this PR's first iteration). |
| #39 | `vand2s_RD` M==1 widened to recognise non-integer scalars: `==`/`!=` are constant; order ops fall back via `*err`. |
| #40 | `and3s` fallback honours `type = "raw"` / `"which"` (an inner `return()` was short-circuiting the type conversion). |
| #47 | `vand2s_II` M==2 `y0 == y1` for OP_BO and OP_BC (only OP_BW was handled; `betweeniiuu(x, y0+1, y0-1)` produced almost-all-true via unsigned wrap-around). |
| (review) | The R-side fallback in `and3s` / `or3s` now coerces raw inputs via `raw2lgl` before `Reduce("&"/"|", …)`. Base `&` rejects raw + logical, so any fallback triggered when `exprA` was a raw mask (e.g. output of a previous `and3s(…, type = "raw")`) used to error. This was a pre-existing fragility surfaced when the new `*err` paths started routing more inputs through the fallback. |

## Audit (#41)

Cor3s.c is clean on the same patterns — no raw variants, all `y0==y1` cases handled, no inner-`return()` bug. Detailed comment posted on #41. The remaining divergence is a *capability gap* (Cor3s lacks raw / string variants); that's a Phase 3 concern.

## Documentation

`?and3s` / `?or3s` now describe the two-valued mask convention for `NA` / `NaN`-valued comparisons. Most visible case: `as.raw(5) > NaN` is `NA` under base R but `FALSE` in the mask under `and3s` (always-true predicates such as `!=` against `NaN` remain `TRUE`). This is the on-CRAN behaviour; the doc just makes it explicit. A regression test pins it.

## Test plan

- [x] `R CMD check` (with `_R_CHECK_FORCE_SUGGESTS_=false` to skip TeXCheckR): `Status: OK`.
- [x] Each fix has a regression test in `inst/tinytest/test-and3s.R`. Where the fix is a value change (most fixes), the test asserts equality against a base-R reference. Where the fix is a path-pin only (#37 — the fall-through is semantically idempotent), the test exercises the path so future regressions surface, with a comment explaining the latency.
- [x] Verified the precomputed-raw-mask case end-to-end: `and3s(mask_raw, rr > 256L)`, `… > 5L`, `… > 5.5` now match base R.

## Version

Bumped to `0.10.12`. NEWS.md updated.

## What's not in this PR

Phases 1–5 of the refactor epic remain tracked separately:

- #42 — invariant-based grid test harness (Phase 1)
- #43 — eliminate first-condition asymmetry (Phase 2)
- #44 — collapse Cand3s/Cor3s duplication (Phase 3)
- #45 — explicit `na`/`unsupported`/`recycle` API (Phase 4)
- #46 — hardening, docs, naming (Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
