### PR TITLE
Phase 1: invariant grid harness for and3s/or3s (closes #42)

### DIFF
--- a/inst/tinytest/test-and3s-grid.R
+++ b/inst/tinytest/test-and3s-grid.R
@@ -1,0 +1,271 @@
+# Phase 1 invariant grid harness for `and3s`. Issue #42.
+#
+# Sweeps the (x_type, y_type, op, M_shape, position) dispatch matrix in
+# vand2s, comparing `and3s` output to a base-R reference. The reference
+# applies NA -> FALSE to logical results to match the documented
+# two-valued mask convention (?and3s "Note on NA / NaN").
+#
+# Cells with `NA` in a unary logical input are deliberately omitted: the
+# package's unary init treats NA as TRUE rather than FALSE, which is a
+# pre-existing divergence from both base R and the doc'd mask convention.
+# That should be reconciled separately.
+#
+# Layout:
+#   Section 1: comparison ops (==, !=, <, <=, >, >=) across numeric type pairs
+#   Section 2: between ops (BW/BO/BC) including degenerate ranges
+#   Section 3: raw type combinations (the most fragile family per Phase 0)
+#   Section 4: %in% / %notin%
+#   Section 5: structural invariants (permutation, position, path, type)
+#   Section 6: documented NaN -> FALSE convention
+#   Section 7: logical and string types
+
+if (requireNamespace("hutilscpp", quietly = TRUE) &&
+    requireNamespace("data.table", quietly = TRUE)) {
+
+library(data.table)
+library(hutilscpp)
+
+"%(between)%" <- hutilscpp:::`%(between)%`
+"%]between[%" <- hutilscpp:::`%]between[%`
+
+n <- 1500  # past the 1000-element fast/fallback boundary in `and3s`
+
+# Coerce NA -> FALSE for the mask-convention reference comparison.
+na2f <- function(x) {
+  if (is.logical(x) && anyNA(x)) x[is.na(x)] <- FALSE
+  x
+}
+
+# Compare an `and3s` call to a base-R reference. Wraps suppressMessages
+# so cells that legitimately fall back don't spam test output.
+g_ <- function(got, want) {
+  expect_equal(suppressMessages(got), na2f(want))
+}
+
+# x-vectors per type. Values chosen to span typical cases (zeros,
+# positives, negatives, edges) so each predicate has both true and
+# false rows.
+ix <- rep_len(c(-1L, 0L, 1L, 5L, 10L, 100L), n)
+dx <- as.double(rep_len(c(-1.5, 0, 1, 5.5, 10, 100), n))
+rx <- as.raw(rep_len(c(0L, 1L, 5L, 100L, 200L, 255L), n))
+sx <- rep_len(c("a", "b", "c"), n)
+
+# y vectors of length n for M==N branches.
+iy <- rep_len(c(0L, 1L, 5L, 10L, 100L, 200L), n)
+dy <- as.double(rep_len(c(0, 1.5, 5, 10, 100, 200), n))
+ry <- as.raw(rep_len(c(0L, 5L, 10L), n))
+
+# ============================================================================
+# Section 1: comparison ops, scalar and vector RHS, numeric type pairs
+# ============================================================================
+
+# --- INT x INT ---
+g_(and3s(ix != 0L, ix == 5L),  (ix != 0L) & (ix == 5L))
+g_(and3s(ix != 0L, ix != 5L),  (ix != 0L) & (ix != 5L))
+g_(and3s(ix != 0L, ix <  5L),  (ix != 0L) & (ix <  5L))
+g_(and3s(ix != 0L, ix <= 5L),  (ix != 0L) & (ix <= 5L))
+g_(and3s(ix != 0L, ix >  5L),  (ix != 0L) & (ix >  5L))
+g_(and3s(ix != 0L, ix >= 5L),  (ix != 0L) & (ix >= 5L))
+g_(and3s(ix != 0L, ix == iy),  (ix != 0L) & (ix == iy))
+g_(and3s(ix != 0L, ix != iy),  (ix != 0L) & (ix != iy))
+g_(and3s(ix != 0L, ix <  iy),  (ix != 0L) & (ix <  iy))
+g_(and3s(ix != 0L, ix >  iy),  (ix != 0L) & (ix >  iy))
+
+# --- INT x DBL ---
+g_(and3s(ix != 0L, ix == 5),    (ix != 0L) & (ix == 5))
+g_(and3s(ix != 0L, ix == 5.5),  (ix != 0L) & (ix == 5.5))
+g_(and3s(ix != 0L, ix >  5.5),  (ix != 0L) & (ix >  5.5))   # OP_GT works
+g_(and3s(ix != 0L, ix >  -1.5), (ix != 0L) & (ix >  -1.5))  # OP_GT works
+# TODO(#49): the following cells are pre-existing INT x DBL M==1 bugs in
+# vand2s_ID's adjustment of y0 for non-integer scalar y. OP_LT, OP_LE,
+# and OP_GE silently give wrong answers. Uncomment once #49 lands.
+#  g_(and3s(ix != 0L, ix <  5.5),  (ix != 0L) & (ix <  5.5))
+#  g_(and3s(ix != 0L, ix <  -1.5), (ix != 0L) & (ix <  -1.5))
+#  g_(and3s(ix != 0L, ix <= 5.5),  (ix != 0L) & (ix <= 5.5))
+#  g_(and3s(ix != 0L, ix <= -1.5), (ix != 0L) & (ix <= -1.5))
+#  g_(and3s(ix != 0L, ix >= 5.5),  (ix != 0L) & (ix >= 5.5))
+#  g_(and3s(ix != 0L, ix >= -1.5), (ix != 0L) & (ix >= -1.5))
+# Out-of-int-range double scalars (these go through a different branch
+# in vand2s_ID with INT_MIN/INT_MAX clamping; not affected by #49).
+g_(and3s(ix != 0L, ix <  1e10),  (ix != 0L) & (ix <  1e10))
+g_(and3s(ix != 0L, ix >  1e10),  (ix != 0L) & (ix >  1e10))
+g_(and3s(ix != 0L, ix == 1e10),  (ix != 0L) & (ix == 1e10))
+g_(and3s(ix != 0L, ix != 1e10),  (ix != 0L) & (ix != 1e10))
+
+# --- DBL x INT ---
+g_(and3s(dx != 0,  dx == 5L),  (dx != 0) & (dx == 5L))
+g_(and3s(dx != 0,  dx <  5L),  (dx != 0) & (dx <  5L))
+g_(and3s(dx != 0,  dx >  5L),  (dx != 0) & (dx >  5L))
+g_(and3s(dx != 0,  dx == iy), (dx != 0) & (dx == iy))
+
+# --- DBL x DBL ---
+g_(and3s(dx != 0,  dx == 5.5),  (dx != 0) & (dx == 5.5))
+g_(and3s(dx != 0,  dx <  5.5),  (dx != 0) & (dx <  5.5))
+g_(and3s(dx != 0,  dx >  5.5),  (dx != 0) & (dx >  5.5))
+g_(and3s(dx != 0,  dx == dy),   (dx != 0) & (dx == dy))
+g_(and3s(dx != 0,  dx <  dy),   (dx != 0) & (dx <  dy))
+
+# ============================================================================
+# Section 2: between ops (BW / BO / BC)
+# Sweeps representative (a, b) pairs including degenerate (a == b) and
+# inverted (a > b) cases. The y0 == y1 corner is the #47 fix.
+# ============================================================================
+
+between_pairs <- list(
+  c(-1L, 5L),    # spans zero
+  c( 0L, 0L),    # degenerate at zero
+  c( 5L, 5L),    # degenerate non-zero (#47)
+  c( 1L, 10L),   # positive
+  c(-5L,-1L),    # negative
+  c(10L, 5L)     # inverted
+)
+for (ab in between_pairs) {
+  a <- ab[1]; b <- ab[2]
+  g_(and3s(ix != 999L, ix %between%   c(a, b)),
+       (ix != 999L) & (ix %between%   c(a, b)))
+  g_(and3s(ix != 999L, ix %(between)% c(a, b)),
+       (ix != 999L) & (ix %(between)% c(a, b)))
+  g_(and3s(ix != 999L, ix %]between[% c(a, b)),
+       (ix != 999L) & (ix %]between[% c(a, b)))
+}
+
+# Double bounds, including fractional and out-of-int-range
+between_dbl_pairs <- list(c(1.5, 5.5), c(-1.5, 5.5), c(0, 0), c(1e10, 2e10))
+for (ab in between_dbl_pairs) {
+  a <- ab[1]; b <- ab[2]
+  g_(and3s(ix != 999L, ix %between%   c(a, b)),
+       (ix != 999L) & (ix %between%   c(a, b)))
+  g_(and3s(dx != 999,  dx %between%   c(a, b)),
+       (dx != 999)  & (dx %between%   c(a, b)))
+  g_(and3s(dx != 999,  dx %(between)% c(a, b)),
+       (dx != 999)  & (dx %(between)% c(a, b)))
+}
+
+# ============================================================================
+# Section 3: raw type combinations (most fragile per Phase 0 review iterations)
+# ============================================================================
+
+# --- RAW x RAW scalar ==/!= ---
+g_(and3s(rx != as.raw(0), rx == as.raw(5)),
+     (rx != as.raw(0)) & (rx == as.raw(5)))
+g_(and3s(rx != as.raw(0), rx != as.raw(5)),
+     (rx != as.raw(0)) & (rx != as.raw(5)))
+
+# --- RAW x INT scalar (in-range, out-of-range, order ops) ---
+g_(and3s(rx != as.raw(0), rx == 5L),
+     (rx != as.raw(0)) & (as.integer(rx) == 5L))
+g_(and3s(rx != as.raw(0), rx == 256L),
+     (rx != as.raw(0)) & FALSE)
+g_(and3s(rx != as.raw(0), rx == -1L),
+     (rx != as.raw(0)) & FALSE)
+# Order ops on raw with in-range integer fall back to base R (kernel
+# only handles ==/!=); harness pins they still match base R.
+g_(and3s(rx != as.raw(0), rx >  5L),
+     (rx != as.raw(0)) & (as.integer(rx) >  5L))
+g_(and3s(rx != as.raw(0), rx <= 5L),
+     (rx != as.raw(0)) & (as.integer(rx) <= 5L))
+# Order ops with out-of-range RHS are constants handled in C.
+g_(and3s(rx != as.raw(0), rx >  256L),
+     (rx != as.raw(0)) & FALSE)
+g_(and3s(rx != as.raw(0), rx >  -1L),
+     (rx != as.raw(0)) & TRUE)
+g_(and3s(rx != as.raw(0), rx <  -1L),
+     (rx != as.raw(0)) & FALSE)
+g_(and3s(rx != as.raw(0), rx <= 256L),
+     (rx != as.raw(0)) & TRUE)
+
+# --- RAW x DBL scalar (fractional, NaN, out-of-range) ---
+g_(and3s(rx != as.raw(0), rx == 5.5),
+     (rx != as.raw(0)) & FALSE)
+g_(and3s(rx != as.raw(0), rx != 5.5),
+     (rx != as.raw(0)) & TRUE)
+g_(and3s(rx != as.raw(0), rx >  5.5),
+     (rx != as.raw(0)) & (as.integer(rx) >  5.5))
+g_(and3s(rx != as.raw(0), rx <= 5.5),
+     (rx != as.raw(0)) & (as.integer(rx) <= 5.5))
+
+# --- RAW x RAW M==N (the #37 fall-through path) ---
+g_(and3s(rx != as.raw(0), rx == ry),
+     (rx != as.raw(0)) & (rx == ry))
+g_(and3s(rx != as.raw(0), rx %notin% ry),
+     (rx != as.raw(0)) & !(rx %in% ry))
+
+# --- Precomputed raw mask reused as exprA ---
+mask_raw <- and3s(rx != as.raw(0), type = "raw")
+mask_lgl <- hutilscpp:::raw2lgl(mask_raw)
+g_(and3s(mask_raw, rx >  5L),    mask_lgl & (as.integer(rx) >  5L))
+g_(and3s(mask_raw, rx >  256L),  mask_lgl & FALSE)
+g_(and3s(mask_raw, rx %in% 5L),  mask_lgl & (as.integer(rx) %in% 5L))
+g_(and3s(mask_raw, rx == 5.5),   mask_lgl & FALSE)
+
+# ============================================================================
+# Section 4: %in% / %notin%
+# The wrapper preprocesses %in% / %notin% via finp / fnotinp before
+# reaching C, so the dispatch path differs from element-wise comparison.
+# ============================================================================
+
+g_(and3s(ix != 0L, ix %in%    c(1L, 5L, 10L)),
+     (ix != 0L) & (ix %in%    c(1L, 5L, 10L)))
+g_(and3s(ix != 0L, ix %notin% c(1L, 5L, 10L)),
+     (ix != 0L) & !(ix %in%   c(1L, 5L, 10L)))
+g_(and3s(dx != 0,  dx %in%    c(1, 5.5, 10)),
+     (dx != 0)  & (dx %in%    c(1, 5.5, 10)))
+
+# ============================================================================
+# Section 5: structural invariants
+# ============================================================================
+
+# --- Permutation invariance over a 3-arg AND chain ---
+ref3 <- (ix > 1L) & (ix < 100L) & (ix != 0L)
+expect_equal(and3s(ix > 1L, ix < 100L, ix != 0L), ref3)
+expect_equal(and3s(ix < 100L, ix != 0L, ix > 1L), ref3)
+expect_equal(and3s(ix != 0L, ix > 1L, ix < 100L), ref3)
+
+# --- Position invariance (predicate as exprA vs exprB) ---
+expect_equal(and3s(ix == 5L, ix != 0L),
+             and3s(ix != 0L, ix == 5L))
+expect_equal(and3s(ix %between% c(1L, 10L), ix != 0L),
+             and3s(ix != 0L, ix %between% c(1L, 10L)))
+
+# --- Path equivalence: small-vector R fallback vs C-side dispatch ---
+ix_short <- ix[seq_len(900)]   # n=900 falls through to .et3 R-side
+ix_long  <- ix
+expect_equal(and3s(ix_short != 0L, ix_short < 5L),
+             head(and3s(ix_long != 0L, ix_long < 5L), 900))
+
+# --- Type equivalence: logical / raw / which agree on the same mask ---
+out_l <- and3s(ix != 0L, ix == 5L, type = "logical")
+out_r <- and3s(ix != 0L, ix == 5L, type = "raw")
+out_w <- and3s(ix != 0L, ix == 5L, type = "which")
+expect_equal(out_l, hutilscpp:::raw2lgl(out_r))
+expect_equal(out_w, which(out_l))
+
+# ============================================================================
+# Section 6: documented NaN -> FALSE convention
+# ?and3s "Note on NA / NaN" -- NaN comparisons evaluate to FALSE in the
+# mask, except != / %notin% against NaN which remain TRUE.
+# ============================================================================
+
+g_(and3s(ix != 999L, ix == NaN),  logical(n))           # always FALSE
+g_(and3s(ix != 999L, ix != NaN),  ix != 999L)            # always TRUE
+g_(and3s(ix != 999L, ix <  NaN),  logical(n))            # always FALSE
+g_(and3s(ix != 999L, ix >  NaN),  logical(n))            # always FALSE
+g_(and3s(rx != as.raw(0), rx >  NaN),  logical(n))       # always FALSE
+g_(and3s(rx != as.raw(0), rx == NaN),  logical(n))       # always FALSE
+g_(and3s(rx != as.raw(0), rx != NaN),  rx != as.raw(0))  # always TRUE
+
+# ============================================================================
+# Section 7: logical and string types
+# (NA inputs avoided; see file header comment.)
+# ============================================================================
+
+lx <- rep_len(c(TRUE, FALSE, FALSE, TRUE), n)
+ly <- rep_len(c(TRUE, TRUE,  FALSE, TRUE), n)
+expect_equal(and3s(lx, ly), lx & ly)
+expect_equal(and3s(lx),     lx)
+
+sy <- rep_len(c("a", "c", "b"), n)
+g_(and3s(sx == "a", sx != "b"), (sx == "a") & (sx != "b"))
+g_(and3s(sx == sy,  sx != "z"), (sx == sy)  & (sx != "z"))
+
+}  # end requireNamespace

--- a/inst/tinytest/test-or3s-grid.R
+++ b/inst/tinytest/test-or3s-grid.R
@@ -1,0 +1,154 @@
+# Phase 1 invariant grid harness for `or3s`. Issue #42.
+#
+# Sweeps the (x_type, y_type, op, M_shape, position) dispatch matrix
+# in vor2s, comparing `or3s` output to a base-R reference. Reference
+# applies NA -> FALSE for the mask convention.
+#
+# Cor3s.c is narrower than Cand3s.c: it implements only the numeric
+# type pairs (II / ID / DI / DD), plus LL / L / SS. Raw type pairs
+# fall through to the wrapper-side fallback (the wrapper preprocesses
+# %in% as logical for `or3s`, so raw `xx1` is uncommon). The harness
+# covers what the kernel handles plus a couple of fallback cells for
+# safety; broader raw coverage is a Phase 3 concern (#44).
+
+if (requireNamespace("hutilscpp", quietly = TRUE) &&
+    requireNamespace("data.table", quietly = TRUE)) {
+
+library(data.table)
+library(hutilscpp)
+
+"%(between)%" <- hutilscpp:::`%(between)%`
+"%]between[%" <- hutilscpp:::`%]between[%`
+
+n <- 1500
+
+na2f <- function(x) {
+  if (is.logical(x) && anyNA(x)) x[is.na(x)] <- FALSE
+  x
+}
+g_ <- function(got, want) {
+  expect_equal(suppressMessages(got), na2f(want))
+}
+
+ix <- rep_len(c(-1L, 0L, 1L, 5L, 10L, 100L), n)
+dx <- as.double(rep_len(c(-1.5, 0, 1, 5.5, 10, 100), n))
+sx <- rep_len(c("a", "b", "c"), n)
+iy <- rep_len(c(0L, 1L, 5L, 10L, 100L, 200L), n)
+dy <- as.double(rep_len(c(0, 1.5, 5, 10, 100, 200), n))
+
+# ============================================================================
+# Section 1: comparison ops, scalar and vector RHS, numeric type pairs
+# ============================================================================
+
+# --- INT x INT ---
+g_(or3s(ix > 99L, ix == 5L),  (ix > 99L) | (ix == 5L))
+g_(or3s(ix > 99L, ix != 5L),  (ix > 99L) | (ix != 5L))
+g_(or3s(ix > 99L, ix <  5L),  (ix > 99L) | (ix <  5L))
+g_(or3s(ix > 99L, ix <= 5L),  (ix > 99L) | (ix <= 5L))
+g_(or3s(ix > 99L, ix >  5L),  (ix > 99L) | (ix >  5L))
+g_(or3s(ix > 99L, ix >= 5L),  (ix > 99L) | (ix >= 5L))
+g_(or3s(ix > 99L, ix == iy),  (ix > 99L) | (ix == iy))
+g_(or3s(ix > 99L, ix <  iy),  (ix > 99L) | (ix <  iy))
+
+# --- INT x DBL ---
+g_(or3s(ix > 99L, ix == 5),    (ix > 99L) | (ix == 5))
+g_(or3s(ix > 99L, ix == 5.5),  (ix > 99L) | (ix == 5.5))
+g_(or3s(ix > 99L, ix <  5.5),  (ix > 99L) | (ix <  5.5))
+g_(or3s(ix > 99L, ix >  5.5),  (ix > 99L) | (ix >  5.5))
+g_(or3s(ix > 99L, ix <  1e10), (ix > 99L) | (ix <  1e10))
+g_(or3s(ix > 99L, ix >  1e10), (ix > 99L) | (ix >  1e10))
+
+# --- DBL x INT ---
+g_(or3s(dx > 99,  dx == 5L),  (dx > 99) | (dx == 5L))
+g_(or3s(dx > 99,  dx <  5L),  (dx > 99) | (dx <  5L))
+g_(or3s(dx > 99,  dx == iy),  (dx > 99) | (dx == iy))
+
+# --- DBL x DBL ---
+g_(or3s(dx > 99,  dx == 5.5),  (dx > 99) | (dx == 5.5))
+g_(or3s(dx > 99,  dx <  5.5),  (dx > 99) | (dx <  5.5))
+g_(or3s(dx > 99,  dx == dy),   (dx > 99) | (dx == dy))
+
+# ============================================================================
+# Section 2: between ops, including degenerate ranges
+# ============================================================================
+
+between_pairs <- list(
+  c(-1L, 5L), c(0L, 0L), c(5L, 5L), c(1L, 10L), c(-5L, -1L), c(10L, 5L)
+)
+for (ab in between_pairs) {
+  a <- ab[1]; b <- ab[2]
+  g_(or3s(ix > 99L, ix %between%   c(a, b)),
+       (ix > 99L) | (ix %between%   c(a, b)))
+  g_(or3s(ix > 99L, ix %(between)% c(a, b)),
+       (ix > 99L) | (ix %(between)% c(a, b)))
+  g_(or3s(ix > 99L, ix %]between[% c(a, b)),
+       (ix > 99L) | (ix %]between[% c(a, b)))
+}
+
+between_dbl_pairs <- list(c(1.5, 5.5), c(0, 0), c(1e10, 2e10))
+for (ab in between_dbl_pairs) {
+  a <- ab[1]; b <- ab[2]
+  g_(or3s(dx > 99, dx %between%   c(a, b)),
+       (dx > 99) | (dx %between%   c(a, b)))
+  g_(or3s(dx > 99, dx %(between)% c(a, b)),
+       (dx > 99) | (dx %(between)% c(a, b)))
+}
+
+# ============================================================================
+# Section 3: %in% / %notin%
+# ============================================================================
+
+g_(or3s(ix > 99L, ix %in%    c(1L, 5L, 10L)),
+     (ix > 99L) | (ix %in%    c(1L, 5L, 10L)))
+g_(or3s(ix > 99L, ix %notin% c(1L, 5L, 10L)),
+     (ix > 99L) | !(ix %in%   c(1L, 5L, 10L)))
+
+# ============================================================================
+# Section 4: structural invariants
+# ============================================================================
+
+# --- Permutation invariance ---
+ref3 <- (ix < 0L) | (ix == 5L) | (ix > 99L)
+expect_equal(or3s(ix < 0L, ix == 5L, ix > 99L), ref3)
+expect_equal(or3s(ix > 99L, ix < 0L, ix == 5L), ref3)
+expect_equal(or3s(ix == 5L, ix > 99L, ix < 0L), ref3)
+
+# --- Position invariance ---
+expect_equal(or3s(ix == 5L, ix > 99L),
+             or3s(ix > 99L, ix == 5L))
+
+# --- Path equivalence ---
+ix_short <- ix[seq_len(900)]
+expect_equal(or3s(ix_short < 0L, ix_short == 5L),
+             head(or3s(ix < 0L, ix == 5L), 900))
+
+# --- Type equivalence ---
+out_l <- or3s(ix > 99L, ix == 5L, type = "logical")
+out_r <- or3s(ix > 99L, ix == 5L, type = "raw")
+out_w <- or3s(ix > 99L, ix == 5L, type = "which")
+expect_equal(out_l, hutilscpp:::raw2lgl(out_r))
+expect_equal(out_w, which(out_l))
+
+# ============================================================================
+# Section 5: documented NaN -> FALSE convention
+# (Symmetric to and3s. NaN comparisons -> FALSE; != / %notin% -> TRUE.)
+# ============================================================================
+
+g_(or3s(ix > 99L, ix == NaN),  ix > 99L)             # NaN -> FALSE; OR identity
+g_(or3s(ix > 99L, ix != NaN),  rep_len(TRUE, n))     # NaN != -> always TRUE
+g_(or3s(ix > 99L, ix <  NaN),  ix > 99L)
+g_(or3s(ix > 99L, ix >  NaN),  ix > 99L)
+
+# ============================================================================
+# Section 6: logical and string types
+# ============================================================================
+
+lx <- rep_len(c(TRUE, FALSE, FALSE, TRUE), n)
+ly <- rep_len(c(FALSE, FALSE, FALSE, TRUE), n)
+expect_equal(or3s(lx, ly), lx | ly)
+
+sy <- rep_len(c("a", "c", "b"), n)
+g_(or3s(sx == "a", sx != "b"), (sx == "a") | (sx != "b"))
+g_(or3s(sx == sy,  sx == "z"), (sx == sy)  | (sx == "z"))
+
+}  # end requireNamespace


### PR DESCRIPTION
Phase 1 of the refactor epic in #36 — invariant grid test harness for `and3s` and `or3s`.

## What this adds

Two new test files that sweep the `(x_type × y_type × op × M_shape × position)` dispatch matrix and compare each cell to a base-R reference:

- `inst/tinytest/test-and3s-grid.R` — 100 cells.
- `inst/tinytest/test-or3s-grid.R` — 60 cells.

The reference applies `NA → FALSE` coercion to logical results, matching the documented two-valued mask convention (?and3s "Note on NA / NaN").

## Coverage

| Section | Content |
|---------|---------|
| 1 | Comparison ops (`==`, `!=`, `<`, `<=`, `>`, `>=`) across INT × INT, INT × DBL, DBL × INT, DBL × DBL, scalar and vector RHS. |
| 2 | Between ops (`%between%`, `%(between)%`, `%]between[%`) including degenerate (`a == b`) and inverted (`a > b`) ranges. |
| 3 | Raw type combinations — the most fragile family per Phase 0: RAW × RAW, RAW × INT, RAW × DBL, in/out-of-range scalars, non-integer scalars, the OP_NI fall-through path, precomputed raw mask as `exprA`. |
| 4 | `%in%` / `%notin%` via wrapper preprocessing. |
| 5 | Structural invariants: 3-arg permutation, position swap, small/long path equivalence (n=900 vs n=1500 — straddles the `.et3` fallback boundary), `type = logical/raw/which` agreement. |
| 6 | Documented `NaN → FALSE` convention. |
| 7 | Logical and string types. |

## Findings during drafting

The harness immediately surfaced a pre-existing bug, filed as **#49**: `vand2s_ID` M==1 silently produces wrong answers for `OP_LT` / `OP_LE` / `OP_GE` against a non-integer scalar `y` (`OP_GT` happens to work — its adjustment lands correctly by accident). 6 cells are commented out with `TODO(#49)` markers; uncomment when that lands.

Also noted (not filed yet): `NA` in a unary logical `exprA` is currently treated as `TRUE` by `Cands`' init path, diverging from both base R and the documented mask convention. Cells with `NA` in logical `xx1` are deliberately omitted here.

## Test plan

- [x] `R CMD check` (with `_R_CHECK_FORCE_SUGGESTS_=false`): `Status: OK`.
- [x] `tinytest::run_test_file("inst/tinytest/test-and3s-grid.R")` — 100 tests OK in 64ms.
- [x] `tinytest::run_test_file("inst/tinytest/test-or3s-grid.R")` — 60 tests OK in 63ms.
- [x] Files are ASCII-only (no em-dashes / arrows).

## What's not in this PR

- Fix for #49 (the LT/LE/GE non-integer bug). Goes in its own PR.
- Higher-n stress (5e4, 1e7) gated by `at_home()`. Worth adding once the matrix coverage is settled.
- Cells with `NA` in unary logical input (the asymmetric init quirk) — needs design discussion.
- `or3s` raw / string capability gap — Phase 3 (#44) territory.

## Why this is the right next step

Every Phase 0 bug, every reviewer iteration on PR #48, and now #49 surfaced from this very same code area share a signature: a corner cell of the dispatch matrix where the kernel does the wrong thing under specific `(type, op, RHS shape)` combinations. With the harness in place, Phase 2 (#43, eliminate first-vs-later asymmetry) and Phase 3 (#44, collapse Cand3s/Cor3s duplication) can be undertaken with a regression net rather than a leap of faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
