### PR TITLE
Phase 2: every kernel uses &= / |=, mask init once (closes #43)

### DIFF
--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -603,15 +603,13 @@ static void vand2s_LL(unsigned char * ansp, const int o,
       } else {
         if (y[0] == 1) {
           if (y[1] == 0) {
-            FORLOOP(ansp[i] = 1;)
+            // always-TRUE predicate: no-op against AND mask
             return;
           }
           FORLOOP(ansp[i] &= x[i] == 1;)
             return;
         }
-        if (y[1] == 1) {
-          FORLOOP(ansp[i] = 1;)
-        }
+        // y[1] == 1 here is also always-TRUE: no-op
         return;
       }
       break;
@@ -1100,32 +1098,29 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
   unsigned char * ansp = RAW(ans);
   int err[1] = {0};
 
+  // Phase 2 invariant: initialise the mask once to all-TRUE, then every
+  // predicate (first or later) ANDs into it. Predicate kernels never
+  // overwrite the mask.
+  memset(ansp, 1, N);
+
   if (TYPEOF(yy1) == NILSXP) {
     switch(TYPEOF(xx1)) {
     case LGLSXP:
     {
       const int * xx1p = LOGICAL(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(
-          ansp[i] = xx1p[i] != 1;
-        )
+        FORLOOP(ansp[i] &= xx1p[i] != 1;)
       } else {
-        FORLOOP(
-          ansp[i] = xx1p[i] != 0;
-        )
+        FORLOOP(ansp[i] &= xx1p[i] != 0;)
       }
     }
       break;
     case RAWSXP: {
       const unsigned char * xx1p = RAW(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(
-          ansp[i] = xx1p[i] != 1;
-        )
+        FORLOOP(ansp[i] &= xx1p[i] != 1;)
       } else {
-        FORLOOP(
-          ansp[i] = xx1p[i] != 0;
-        )
+        FORLOOP(ansp[i] &= xx1p[i] != 0;)
       }
     }
       break;
@@ -1136,9 +1131,6 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
     }
     // # nocov end
   } else {
-    FORLOOP({
-      ansp[i] = 1;
-    })
     vand2s(ansp, o1, xx1, yy1, nThread, err);
   }
   if (use2) {

--- a/src/Cor3s.c
+++ b/src/Cor3s.c
@@ -445,7 +445,8 @@ static void vo2s_LL(unsigned char * ansp, const int o,
     switch(o) {
     case OP_BW:
       if (y[0] == 0 && y[1] == 1) {
-        FORLOOP(ansp[i] = 1;)
+        // always-TRUE predicate: OR with all-1 saturates the mask
+        memset(ansp, 1, N);
         return;
       } else {
         int y00 = y[0] == NA_LOGICAL ? 0 : y[0];
@@ -464,14 +465,15 @@ static void vo2s_LL(unsigned char * ansp, const int o,
       } else {
         if (y[0] == 1) {
           if (y[1] == 0) {
-            FORLOOP(ansp[i] = 1;)
+            // always-TRUE predicate: saturate
+            memset(ansp, 1, N);
             return;
           }
           FORLOOP(ansp[i] |= x[i] == 1;)
             return;
         }
         if (y[1] == 1) {
-          FORLOOP(ansp[i] = 1;)
+          memset(ansp, 1, N);
         }
         return;
       }
@@ -656,21 +658,19 @@ SEXP Cors(SEXP oo1, SEXP xx1, SEXP yy1,
   unsigned char * ansp = RAW(ans);
   int err[1] = {0};
 
+  // Phase 2 invariant: initialise the mask once to all-FALSE, then every
+  // predicate (first or later) ORs into it. Predicate kernels never
+  // overwrite the mask.
+  memset(ansp, 0, N);
+
   if (yy1 == R_NilValue && isLogical(xx1)) {
     const int * xx1p = LOGICAL(xx1);
     if (o1 == OP_NE) {
-      FORLOOP(
-        ansp[i] = xx1p[i] != 1;
-      )
+      FORLOOP(ansp[i] |= xx1p[i] != 1;)
     } else {
-      FORLOOP(
-        ansp[i] = xx1p[i] != 0;
-      )
+      FORLOOP(ansp[i] |= xx1p[i] != 0;)
     }
   } else {
-    FORLOOP(
-      ansp[i] = 0;
-    )
     vor2s(ansp, o1, xx1, yy1, nThread, err);
   }
   if (use2) {


### PR DESCRIPTION
Phase 2 of the refactor epic in #36 — eliminate the first-vs-later position asymmetry in `and3s` / `or3s`.

## Context

Through Phase 0 (and the iterative reviews on #48), every reproducible bug had the same shape: a leaf branch wrote `ansp[i] = ...` when it should have written `ansp[i] &= ...` (or `|=`). The architecture invited this: the *first* condition initialised the mask via direct assignment, while *later* conditions had to mutate it. Each leaf branch had to remember which mode it was in, and any slip silently revived previously-rejected rows.

This PR retires that bug class structurally.

## Changes

- **`Cands`**: now `memset(ansp, 1, N)` once up front, regardless of branch. The `FORLOOP(ansp[i] = 1)` that initialised the binary path is dropped.
- **`Cors`**: same with `memset(ansp, 0, N)` (all-0 for the OR identity).
- **Unary form (`yy1 == NILSXP`)**: was `ansp[i] = xx1p[i] != 0/1`; now `&=` (or `|=` for `or3s`). Against the all-1 (or all-0) init mask, semantics for the standalone unary call are unchanged; the change matters when this path is composed with later predicates.
- **`vand2s_LL` OP_WB nocov branches** (Cand3s.c:606, 613): `FORLOOP(ansp[i] = 1)` for always-TRUE predicates is replaced with bare `return;`. Under the new invariant the mask is already 1 and the predicate is a no-op against the AND chain. The previous overwrite would have clobbered prior conditions if the path were ever reachable.
- **`vor2s_LL` OP_BW / OP_WB always-TRUE branches** (Cor3s.c:448, 467, 474): `FORLOOP(ansp[i] = 1)` switched to `memset(ansp, 1, N)`. Semantically equivalent for OR (saturates the mask) but declarative form separates "saturate" from "predicate kernel".

The remaining direct `ansp[i] = …` writes in the kernels are all *guarded* by `if (ansp[i])` / `if (ansp[i] == 0) continue;` short-circuits, which makes them functionally `&=` already — they only execute when the mask is in the appropriate state. They're left as-is to preserve the per-row early-out (real perf win when many rows are already eliminated).

## Test plan

- [x] **Phase 1 grid harness** (#42, 160 cells) passes both before and after this change. The harness was specifically built as a regression net for refactors of this kind.
- [x] Existing `test-and3s.R`, `test-or3s.R`, `test-sum_and3s.R`, etc. all pass.
- [x] `R CMD check` (`_R_CHECK_FORCE_SUGGESTS_=false`): `Status: OK`.

## What this enables

Phase 3 (#44) — collapse Cand3s.c / Cor3s.c duplication — is now straightforward: every kernel obeys the same template, parameterised on the combine op (`&=` vs `|=`). With a single shared dispatcher, the two files would shrink from ~1800 LOC to ~600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
