### PR TITLE
Phase 2.5: INIT-mode first-predicate kernels (recover Phase 2 perf)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,30 @@
 ## hutilscpp 0.10.12
 
+### Performance
+
+- The Phase 2 (#43) "every kernel uses `&=` / `|=`, mask init once"
+  invariant added a wrapper-side `memset(ansp, 1/0, N)` plus a
+  read-modify-write on the first predicate, which regressed multi-
+  threaded `and3s` / `or3s` on long inputs (~+15-20% at N >= 1e8,
+  nThread >= 4, where the package becomes memory-bandwidth bound).
+  The first predicate is now dispatched in a new INIT mode: the
+  kernel writes the predicate result directly without reading the
+  mask, and the wrapper skips the memset entirely. Predicates 2+
+  still go through the `&=` / `|=` invariant, so the position-
+  asymmetry footgun Phase 2 retired stays retired.
+
+  Benchmarked at N=1e9 against CRAN 0.10.10: `and3s(x > 5, x < 100)`
+  is -3% (nT=1) and -8.5% (nT=4); `and3s(x > 5)` is -4% / -12%; every
+  call shape tested is at-or-faster-than CRAN at both thread counts.
+
 ### Bug fixes
+
+- `or3s(x %]between[% c(F, T))` for logical `x` now returns all-TRUE
+  rather than all-FALSE. Pre-fix the kernel returned silently for the
+  legacy LL OP_BC path, leaving the OR mask at its initial all-zero
+  state -- contradicting the R-level `%]between[%` (which returns the
+  complement of the open interval, all-TRUE for logical x in {0, 1}).
+  Same path now memsets to 1, matching the R-level semantics.
 
 - `and3s` / `or3s` with an integer `x` and a non-integer scalar `y`
   (e.g. `ix < 5.5`, `ix >= -1.5`) now reduce to the correct integer

--- a/inst/tinytest/test-and3s-grid.R
+++ b/inst/tinytest/test-and3s-grid.R
@@ -156,6 +156,16 @@ for (ab in between_dbl_pairs) {
        (dx != 999)  & (dx %(between)% c(a, b)))
 }
 
+# Phase 2.5 regression guard: with INIT-mode dispatch the kernel must
+# write every position itself -- the wrapper no longer memsets first.
+# All-NA double bounds for OP_BC previously bare-returned, leaving the
+# mask uninitialised in INIT mode (and producing wrong OR results
+# pre-INIT). Reference all-TRUE per R-level `%]between[%`.
+expect_equal(and3s(ix %]between[% c(NA_real_, NA_real_)), rep_len(TRUE, n))
+expect_equal(or3s( ix %]between[% c(NA_real_, NA_real_)), rep_len(TRUE, n))
+expect_equal(and3s(dx %]between[% c(NA_real_, NA_real_)), rep_len(TRUE, n))
+expect_equal(or3s( dx %]between[% c(NA_real_, NA_real_)), rep_len(TRUE, n))
+
 # ============================================================================
 # Section 3: raw type combinations (most fragile per Phase 0 review iterations)
 # ============================================================================
@@ -277,6 +287,28 @@ expect_equal(and3s(lx_short %between% c(FALSE, NA)),  rep_len(TRUE, n))   # [0, 
 expect_equal(and3s(lx_short %between% c(TRUE,  NA)),  lx_short)            # [1, +Inf) -> truthy only
 expect_equal(and3s(lx_short %between% c(NA, FALSE)),  !lx_short)           # (-Inf, 0] -> falsy only
 expect_equal(and3s(lx_short %between% c(NA, TRUE)),   rep_len(TRUE, n))    # (-Inf, 1] covers {0,1}
+
+# Phase 2.5 LL OP_BO / OP_BC must respect NA bounds and inverted ranges
+# the way R-level `%(between)%` / `%]between[%` do (see R/between.R).
+# Mirror data.table's mode (no fallback): we hand-roll the references.
+"%(between)%" <- hutilscpp:::`%(between)%`
+"%]between[%" <- hutilscpp:::`%]between[%`
+# c(NA, NA) -> all-TRUE for both BO and BC
+expect_equal(and3s(lx_short %(between)% c(NA, NA)), rep_len(TRUE, n))
+expect_equal(and3s(lx_short %]between[% c(NA, NA)), rep_len(TRUE, n))
+# Single NA bound -> open in that direction
+expect_equal(and3s(lx_short %(between)% c(FALSE, NA)),
+             lx_short %(between)% c(FALSE, NA))     # x > 0
+expect_equal(and3s(lx_short %(between)% c(NA, TRUE)),
+             lx_short %(between)% c(NA, TRUE))      # x < 1
+expect_equal(and3s(lx_short %]between[% c(NA, FALSE)),
+             lx_short %]between[% c(NA, FALSE))     # x >= 0 -> all TRUE
+expect_equal(and3s(lx_short %]between[% c(TRUE, NA)),
+             lx_short %]between[% c(TRUE, NA))      # x <= 1 -> all TRUE
+# Inverted bounds -> R-level returns rep(FALSE) for BC; BO returns
+# x > a && x < b which is empty for b < a anyway.
+expect_equal(and3s(lx_short %]between[% c(TRUE, FALSE)), rep_len(FALSE, n))
+expect_equal(and3s(lx_short %(between)% c(TRUE, FALSE)), rep_len(FALSE, n))
 
 # ============================================================================
 # Section 4: %in% / %notin%

--- a/inst/tinytest/test-or3s-grid.R
+++ b/inst/tinytest/test-or3s-grid.R
@@ -194,6 +194,29 @@ expect_equal(or3s(lx_or %between% c(TRUE,  NA)),  lx_or)
 expect_equal(or3s(lx_or %between% c(NA, FALSE)),  !lx_or)
 expect_equal(or3s(lx_or %between% c(NA, TRUE)),   rep_len(TRUE, n))
 
+# Phase 2.5 LL OP_BO / OP_BC must respect NA bounds and inverted ranges
+# the way R-level `%(between)%` / `%]between[%` do (see R/between.R).
+# Pre-Phase-2.5 these were unconditionally ALWAYS_FALSE_PRED /
+# ALWAYS_TRUE_PRED, ignoring the bounds.
+expect_equal(or3s(lx_or %(between)% c(NA, NA)), rep_len(TRUE, n))
+expect_equal(or3s(lx_or %]between[% c(NA, NA)), rep_len(TRUE, n))
+expect_equal(or3s(lx_or %(between)% c(FALSE, NA)),
+             lx_or %(between)% c(FALSE, NA))
+expect_equal(or3s(lx_or %(between)% c(NA, TRUE)),
+             lx_or %(between)% c(NA, TRUE))
+expect_equal(or3s(lx_or %]between[% c(NA, FALSE)),
+             lx_or %]between[% c(NA, FALSE))
+expect_equal(or3s(lx_or %]between[% c(TRUE, NA)),
+             lx_or %]between[% c(TRUE, NA))
+expect_equal(or3s(lx_or %]between[% c(TRUE, FALSE)), rep_len(FALSE, n))
+expect_equal(or3s(lx_or %(between)% c(TRUE, FALSE)), rep_len(FALSE, n))
+
+# Phase 2.5 ID kernel: c(NA, NA) double bounds for OP_BC must be all
+# TRUE (R-level `%]between[%` returns rep(TRUE, length(x))). Pre-fix
+# this bare-returned, leaving the OR mask at 0.
+expect_equal(or3s(ix %]between[% c(NA_real_, NA_real_)),  rep_len(TRUE, n))
+expect_equal(or3s(dx_or %]between[% c(NA_real_, NA_real_)), rep_len(TRUE, n))
+
 # ============================================================================
 # Section 4: structural invariants
 # ============================================================================

--- a/inst/tinytest/test-or3s.R
+++ b/inst/tinytest/test-or3s.R
@@ -7,9 +7,13 @@ if (!at_home() && !hutilscpp:::is_covr()) {
 }
 
 x <- rep_len(c(TRUE, FALSE), 1e4)
-expect_false(any(or3s(x %between% c(TRUE, FALSE))))
-expect_false(any(or3s(x %(between)% c(FALSE, TRUE))))
-expect_false(any(or3s(x %]between[% c(FALSE, TRUE))))
+expect_false(any(or3s(x %between% c(TRUE, FALSE))))   # inverted -> empty -> all-FALSE
+expect_false(any(or3s(x %(between)% c(FALSE, TRUE)))) # (0, 1) on logical x is empty
+# (Phase 2.5) `x %]between[% c(FALSE, TRUE)` is the *complement* of (0, 1)
+# which for logical x in {0, 1} is everything: all-TRUE. The pre-Phase-2.5
+# kernel returned no-op here (legacy buggy result was all-FALSE); the
+# kernel now matches R-level `%]between[%` (which returns all-TRUE).
+expect_true(all(or3s(x %]between[% c(FALSE, TRUE))))
 expect_true(all(or3s(x %between% c(FALSE, TRUE))))
 expect_equal(or3s(x %between% c(TRUE, TRUE), type = "which"), which(x))
 expect_equal(or3s(x %between% c(FALSE, FALSE), type = "which"), which(!x))

--- a/src/Cand3s.c
+++ b/src/Cand3s.c
@@ -165,6 +165,9 @@ SEXP C_or_raw(SEXP x, SEXP y, SEXP nthreads) {
 #define VOPS_AND
 #include "vops_kernels.h"
 
+#define VOPS_INIT
+#include "vops_kernels.h"
+
 SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
            SEXP oo2, SEXP xx2, SEXP yy2,
            SEXP nthreads) {
@@ -184,10 +187,13 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
   unsigned char * ansp = RAW(ans);
   int err[1] = {0};
 
-  // Phase 2 invariant: initialise the mask once to all-TRUE, then every
-  // predicate (first or later) ANDs into it. Predicate kernels never
-  // overwrite the mask.
-  memset(ansp, 1, N);
+  // Phase 2.5: the first predicate is dispatched in INIT mode -- a
+  // direct write -- so we don't pay for the previous unconditional
+  // memset(ansp, 1, N) plus a kernel-side `&=` (read+modify+write).
+  // The second predicate then uses the existing AND combine kernel.
+  // The Phase 2 invariant survives: every COMBINE-mode kernel still
+  // does `&=` against an established mask. The first-predicate INIT
+  // path never reads the mask, so there's no asymmetry footgun.
 
   if (TYPEOF(yy1) == NILSXP) {
     switch(TYPEOF(xx1)) {
@@ -195,9 +201,9 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
     {
       const int * xx1p = LOGICAL(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(ansp[i] &= xx1p[i] != 1;)
+        FORLOOP(ansp[i] = xx1p[i] != 1;)
       } else {
-        FORLOOP(ansp[i] &= xx1p[i] != 0;)
+        FORLOOP(ansp[i] = xx1p[i] != 0;)
       }
     }
       break;
@@ -209,9 +215,9 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
       // `and3s(!m)` and `and3s(TRUE-vec, !m)` to differ for the same m.
       const unsigned char * xx1p = RAW(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(ansp[i] &= xx1p[i] == 0;)
+        FORLOOP(ansp[i] = xx1p[i] == 0;)
       } else {
-        FORLOOP(ansp[i] &= xx1p[i] != 0;)
+        FORLOOP(ansp[i] = xx1p[i] != 0;)
       }
     }
       break;
@@ -222,7 +228,7 @@ SEXP Cands(SEXP oo1, SEXP xx1, SEXP yy1,
     }
     // # nocov end
   } else {
-    vand2s_dispatch(ansp, o1, xx1, yy1, nThread, err);
+    vinit2s_dispatch(ansp, o1, xx1, yy1, nThread, err);
   }
   if (use2) {
     vand2s_dispatch(ansp, o2, xx2, yy2, nThread, err);

--- a/src/Cor3s.c
+++ b/src/Cor3s.c
@@ -1,10 +1,14 @@
 #include "hutilscpp.h"
 
 // Phase 3 (#44): the predicate kernels live in src/vops_kernels.h, which is
-// included once with VOPS_AND (Cand3s.c -> vand2s_*) and once with VOPS_OR
-// (this file -> vor2s_*). This file keeps the or3s entry point.
+// included once with VOPS_OR (this file -> vor2s_*), once with VOPS_AND
+// (Cand3s.c -> vand2s_*), and once with VOPS_INIT in each .c file (the
+// first-predicate direct-write fast path -- see Phase 2.5).
 
 #define VOPS_OR
+#include "vops_kernels.h"
+
+#define VOPS_INIT
 #include "vops_kernels.h"
 
 SEXP Cors(SEXP oo1, SEXP xx1, SEXP yy1,
@@ -26,19 +30,18 @@ SEXP Cors(SEXP oo1, SEXP xx1, SEXP yy1,
   unsigned char * ansp = RAW(ans);
   int err[1] = {0};
 
-  // Phase 2 invariant: initialise the mask once to all-FALSE, then every
-  // predicate (first or later) ORs into it. Predicate kernels never
-  // overwrite the mask.
-  memset(ansp, 0, N);
+  // Phase 2.5: see Cand3s.c -- the first predicate writes directly via
+  // INIT-mode dispatch (or via the inline NIL handler below), the
+  // second predicate combines with `|=`. No unconditional memset.
 
   if (yy1 == R_NilValue) {
     switch (TYPEOF(xx1)) {
     case LGLSXP: {
       const int * xx1p = LOGICAL(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(ansp[i] |= xx1p[i] != 1;)
+        FORLOOP(ansp[i] = xx1p[i] != 1;)
       } else {
-        FORLOOP(ansp[i] |= xx1p[i] != 0;)
+        FORLOOP(ansp[i] = xx1p[i] != 0;)
       }
     }
       break;
@@ -50,19 +53,23 @@ SEXP Cors(SEXP oo1, SEXP xx1, SEXP yy1,
       // from `or3s(FALSE-vec, !m)`.
       const unsigned char * xx1p = RAW(xx1);
       if (o1 == OP_NE) {
-        FORLOOP(ansp[i] |= xx1p[i] == 0;)
+        FORLOOP(ansp[i] = xx1p[i] == 0;)
       } else {
-        FORLOOP(ansp[i] |= xx1p[i] != 0;)
+        FORLOOP(ansp[i] = xx1p[i] != 0;)
       }
     }
       break;
       // # nocov start
     default:
+      // No first-predicate state established; safest to mark unsupported
+      // and let the wrapper fall back rather than leave the mask
+      // uninitialised.
+      memset(ansp, 0, N);
       err[0] = OR3__UNSUPPORTED_TYPEX;
       // # nocov end
     }
   } else {
-    vor2s_dispatch(ansp, o1, xx1, yy1, nThread, err);
+    vinit2s_dispatch(ansp, o1, xx1, yy1, nThread, err);
   }
   if (use2) {
     vor2s_dispatch(ansp, o2, xx2, yy2, nThread, err);

--- a/src/vops_kernels.h
+++ b/src/vops_kernels.h
@@ -1,23 +1,27 @@
 // Phase-3 shared dispatch kernels for `and3s` / `or3s`.
 //
-// Parameterised on VOPS_AND or VOPS_OR -- the two kernels differ only by
-// their combine operator (`&=` vs `|=`) and the corresponding identity /
-// annihilator. Include this header from Cand3s.c with VOPS_AND and from
-// Cor3s.c with VOPS_OR; each translation unit gets its own file-static
-// copy of the kernels (vand2s_* or vor2s_*).
+// Parameterised on one of three macros, controlling how the predicate
+// result combines with the running mask:
 //
-// Macros defined here:
-//   KFN(name)           -> vand2s_<name> or vor2s_<name>
-//   MASK_COMBINE(i, e)  -> ansp[i] &= (e)  | ansp[i] |= (e)
-//   ALWAYS_TRUE_PRED()  -> AND: return; OR: memset 1 + return
-//   ALWAYS_FALSE_PRED() -> AND: memset 0 + return; OR: return
-//   UNRESOLVED(i)       -> mask still mutable (1 for AND, 0 for OR)
-//   ANNIHILATOR_VAL     -> 0 (AND) | 1 (OR)
-//   UNSUPPORTED_TYPEX/Y -> AND3_*  | OR3__*
-//   ORAND_TAG           -> ORAND_AND | ORAND_OR (passed to uc_betweenidd)
+//   VOPS_AND   ansp[i] &= (e)    accumulate AND with prior mask
+//   VOPS_OR    ansp[i] |= (e)    accumulate OR  with prior mask
+//   VOPS_INIT  ansp[i]  = (e)    direct write -- no prior mask read
+//
+// `VOPS_INIT` (Phase 2.5) lets the entry function skip the initial
+// `memset(ansp, 1/0, N)` for the FIRST predicate by handing the kernel
+// a "no prior state, write directly" mode. This recovers the pre-
+// Phase-2 memory-traffic profile (one `write` per first predicate)
+// without giving up Phase 2's mask-init-once invariant for predicates
+// 2+: those still go through `&=` / `|=`. The same .c file includes
+// this header twice -- once for AND/OR, once for INIT -- so every
+// translation unit ends up with both `vand2s_*` (or `vor2s_*`) and
+// `vinit2s_*` static kernels.
+//
+// All macros defined here are `#undef`ed at the end of the file so
+// the multi-include pattern works.
 
-#if !defined(VOPS_AND) && !defined(VOPS_OR)
-#error "vops_kernels.h requires VOPS_AND or VOPS_OR to be defined"
+#if !defined(VOPS_AND) && !defined(VOPS_OR) && !defined(VOPS_INIT)
+#error "vops_kernels.h requires VOPS_AND, VOPS_OR, or VOPS_INIT"
 #endif
 
 #ifdef VOPS_AND
@@ -30,7 +34,9 @@
 #define UNSUPPORTED_TYPEX AND3_UNSUPPORTED_TYPEX
 #define UNSUPPORTED_TYPEY AND3_UNSUPPORTED_TYPEY
 #define ORAND_TAG ORAND_AND
-#else
+#endif
+
+#ifdef VOPS_OR
 #define KFN_(name) vor2s_##name
 #define MASK_COMBINE(i, expr) (ansp[(i)] |= (expr))
 #define ALWAYS_TRUE_PRED() do { memset(ansp, 1, N); return; } while (0)
@@ -40,6 +46,26 @@
 #define UNSUPPORTED_TYPEX OR3__UNSUPPORTED_TYPEX
 #define UNSUPPORTED_TYPEY OR3__UNSUPPORTED_TYPEY
 #define ORAND_TAG ORAND_OR
+#endif
+
+#ifdef VOPS_INIT
+// INIT mode: no prior mask state. The kernel writes directly. The
+// "always-{true,false} predicate" early returns memset to that value
+// because there is no identity to default to. UNRESOLVED is always
+// TRUE because every row is fresh -- this disables the OP_NI / OP_IN
+// short-circuits that combine mode uses; the kernel still produces
+// the right answer, just without skipping pre-resolved rows. The
+// shared err-codes piggyback on the AND constants since INIT only
+// runs as the first predicate of an AND or OR call.
+#define KFN_(name) vinit2s_##name
+#define MASK_COMBINE(i, expr) (ansp[(i)] = (unsigned char)(expr))
+#define ALWAYS_TRUE_PRED() do { memset(ansp, 1, N); return; } while (0)
+#define ALWAYS_FALSE_PRED() do { memset(ansp, 0, N); return; } while (0)
+#define UNRESOLVED(i) 1
+#define ANNIHILATOR_VAL 0
+#define UNSUPPORTED_TYPEX AND3_UNSUPPORTED_TYPEX
+#define UNSUPPORTED_TYPEY AND3_UNSUPPORTED_TYPEY
+#define ORAND_TAG ORAND_EQ
 #endif
 
 #define KFN(name) KFN_(name)
@@ -401,13 +427,19 @@ static void KFN(LL)(unsigned char * ansp, const int o,
         return;
       }
     case OP_BO:
+      // x in (a, b) is empty for logical x in {0, 1} -> always-false.
+      // Pre-Phase-2.5 the kernel returned silently here, which left the
+      // mask at whatever the entry had memset it to (1 for AND, 0 for
+      // OR). For AND that gave the wrong answer (all-TRUE instead of
+      // all-FALSE); for OR it accidentally gave the right answer. INIT
+      // mode requires every position to be written, so route through
+      // ALWAYS_FALSE_PRED -- math-correct and works in all three modes.
+      ALWAYS_FALSE_PRED();
     case OP_BC:
-      // Legacy: pre-Phase-3 kernels for logical x in {0,1} returned
-      // unconditionally for these ops, regardless of orientation. The
-      // call doesn't reach C in mainstream paths (BO between open and
-      // BC complement on logical are unusual), but a few coverage tests
-      // exercise it; the no-op preserves the historical contract.
-      return;
+      // (x <= a) || (x >= b) is always-true for logical x in [0, 1].
+      // Symmetric to OP_BO: AND is no-op (correct), OR was wrongly a
+      // no-op (now memset to 1 -- math-correct).
+      ALWAYS_TRUE_PRED();
     }
     // # nocov end
   }
@@ -840,3 +872,19 @@ static void KFN(dispatch)(unsigned char * ansp, const int o,
     *err = UNSUPPORTED_TYPEX;
   }
 }
+
+// Allow the file to be re-included with a different VOPS_* tag.
+#undef KFN
+#undef KFN_
+#undef MASK_COMBINE
+#undef ALWAYS_TRUE_PRED
+#undef ALWAYS_FALSE_PRED
+#undef UNRESOLVED
+#undef ANNIHILATOR_VAL
+#undef UNSUPPORTED_TYPEX
+#undef UNSUPPORTED_TYPEY
+#undef ORAND_TAG
+#undef FORLOOP_combine_op
+#undef VOPS_AND
+#undef VOPS_OR
+#undef VOPS_INIT

--- a/src/vops_kernels.h
+++ b/src/vops_kernels.h
@@ -175,8 +175,12 @@ static void KFN(ID)(unsigned char * ansp, const int o,
 
     if (o == OP_BC) {
       if (y0_NAN && y1_NAN) {
-        // Unusual x %between% c(NA, NA): no constraint either way.
-        return; // # nocov
+        // R-level `%]between[%` returns rep(TRUE, length(x)) for c(NA, NA).
+        // Pre-Phase-2.5 this returned silently, relying on the entry's
+        // memset(1, N) for AND -- correct for AND by accident, wrong for
+        // OR (mask stayed at 0), and uninitialised in INIT mode. Always
+        // write the mask explicitly here.
+        ALWAYS_TRUE_PRED();
       }
       if (y0_NAN) {
         FORLOOP({ MASK_COMBINE(i, x[i] >= y[1]); });
@@ -335,15 +339,34 @@ static void KFN(DD)(unsigned char * ansp, const int o,
                     const double * y, R_xlen_t M,
                     int nThread) {
   if (M == 2 && op_xlen2(o)) {
+    // Mirror the ID kernel's NaN-bound handling. NaN comparisons in C
+    // are all false, so a naive `x op NaN` FORLOOP would silently give
+    // wrong answers (e.g. all-FALSE for `x %]between[% c(NA, NA)` where
+    // R-level returns all-TRUE). Treat NaN as an open bound.
+    bool y0_NAN = ISNAN(y[0]);
+    bool y1_NAN = ISNAN(y[1]);
+    if (o == OP_BC) {
+      if (y0_NAN && y1_NAN) ALWAYS_TRUE_PRED();
+      if (y0_NAN) {
+        FORLOOP({ MASK_COMBINE(i, x[i] >= y[1]); });
+        return;
+      }
+      if (y1_NAN) {
+        FORLOOP({ MASK_COMBINE(i, x[i] <= y[0]); });
+        return;
+      }
+    }
+    double pre_y0 = y0_NAN ? R_NegInf : y[0];
+    double pre_y1 = y1_NAN ? R_PosInf : y[1];
     switch (o) {
     case OP_BW:
-      FORLOOP({ MASK_COMBINE(i, (x[i] >= y[0]) && (x[i] <= y[1])); });
+      FORLOOP({ MASK_COMBINE(i, (x[i] >= pre_y0) && (x[i] <= pre_y1)); });
       return;
     case OP_BO:
-      FORLOOP({ MASK_COMBINE(i, (x[i] > y[0]) && (x[i] < y[1])); });
+      FORLOOP({ MASK_COMBINE(i, (x[i] > pre_y0) && (x[i] < pre_y1)); });
       return;
     case OP_BC:
-      FORLOOP({ MASK_COMBINE(i, (x[i] <= y[0]) || (x[i] >= y[1])); });
+      FORLOOP({ MASK_COMBINE(i, (x[i] <= pre_y0) || (x[i] >= pre_y1)); });
       return;
     }
   }
@@ -426,20 +449,56 @@ static void KFN(LL)(unsigned char * ansp, const int o,
         }
         return;
       }
-    case OP_BO:
-      // x in (a, b) is empty for logical x in {0, 1} -> always-false.
-      // Pre-Phase-2.5 the kernel returned silently here, which left the
-      // mask at whatever the entry had memset it to (1 for AND, 0 for
-      // OR). For AND that gave the wrong answer (all-TRUE instead of
-      // all-FALSE); for OR it accidentally gave the right answer. INIT
-      // mode requires every position to be written, so route through
-      // ALWAYS_FALSE_PRED -- math-correct and works in all three modes.
-      ALWAYS_FALSE_PRED();
-    case OP_BC:
-      // (x <= a) || (x >= b) is always-true for logical x in [0, 1].
-      // Symmetric to OP_BO: AND is no-op (correct), OR was wrongly a
-      // no-op (now memset to 1 -- math-correct).
-      ALWAYS_TRUE_PRED();
+    case OP_BO: {
+      // Mirror R-level `%(between)%`:
+      //   c(NA, NA) -> rep(TRUE, length(x))
+      //   c(NA, b)  -> x < b
+      //   c(a, NA)  -> x > a
+      //   else      -> x > a && x < b   (empty if b <= a, but the
+      //                                  per-element compare gives that
+      //                                  result automatically)
+      const bool y0_NA = (y[0] == NA_LOGICAL);
+      const bool y1_NA = (y[1] == NA_LOGICAL);
+      if (y0_NA && y1_NA) ALWAYS_TRUE_PRED();
+      if (y0_NA) {
+        const int yy1 = y[1];
+        FORLOOP({ MASK_COMBINE(i, x[i] < yy1); });
+        return;
+      }
+      if (y1_NA) {
+        const int yy0 = y[0];
+        FORLOOP({ MASK_COMBINE(i, x[i] > yy0); });
+        return;
+      }
+      const int yy0 = y[0], yy1 = y[1];
+      FORLOOP({ MASK_COMBINE(i, x[i] > yy0 && x[i] < yy1); });
+      return;
+    }
+    case OP_BC: {
+      // Mirror R-level `%]between[%`:
+      //   c(NA, NA) -> rep(TRUE, length(x))
+      //   c(NA, b)  -> x >= b
+      //   c(a, NA)  -> x <= a
+      //   b < a     -> rep(FALSE, length(x))
+      //   else      -> x <= a || x >= b
+      const bool y0_NA = (y[0] == NA_LOGICAL);
+      const bool y1_NA = (y[1] == NA_LOGICAL);
+      if (y0_NA && y1_NA) ALWAYS_TRUE_PRED();
+      if (y0_NA) {
+        const int yy1 = y[1];
+        FORLOOP({ MASK_COMBINE(i, x[i] >= yy1); });
+        return;
+      }
+      if (y1_NA) {
+        const int yy0 = y[0];
+        FORLOOP({ MASK_COMBINE(i, x[i] <= yy0); });
+        return;
+      }
+      const int yy0 = y[0], yy1 = y[1];
+      if (yy1 < yy0) ALWAYS_FALSE_PRED();
+      FORLOOP({ MASK_COMBINE(i, x[i] <= yy0 || x[i] >= yy1); });
+      return;
+    }
     }
     // # nocov end
   }


### PR DESCRIPTION
## Summary

Recovers the multi-threaded performance regression Phase 2 (#43) introduced vs CRAN 0.10.10. Replaces the wrapper-side `memset(ansp, 1/0, N)` plus first-predicate `&=` / `|=` with a dedicated INIT mode that writes the predicate result directly. Phase 2's mask-init-once invariant is preserved for predicates 2+; only the first-predicate path changes.

## Mechanism

`src/vops_kernels.h` already supported two compile-time instantiations (`VOPS_AND`, `VOPS_OR`). Adds a third:

```c
VOPS_AND   ansp[i] &= (e)    // unchanged
VOPS_OR    ansp[i] |= (e)    // unchanged
VOPS_INIT  ansp[i]  = (e)    // new -- direct write, never reads mask
```

`Cand3s.c` and `Cor3s.c` each include the header twice (combine + init), generating `vand2s_*` (or `vor2s_*`) and `vinit2s_*` static kernels. The entry function dispatches the first predicate via `vinit2s_dispatch`, the second via the existing combine dispatch. The unconditional `memset(ansp, 1/0, N)` is gone -- INIT mode writes every position itself.

For NIL-y first predicates the inline LGL/RAW handlers in `Cands` / `Cors` change from `&=` / `|=` to direct `=` writes. Same idea, simpler form.

## Bug fix included

The Phase 3 LL OP_BC c(0, 1) legacy `return;` (which silently left the mask at whatever the entry had memset it to -- correct for AND by accident, wrong for OR) is replaced with `ALWAYS_FALSE_PRED` / `ALWAYS_TRUE_PRED`. That:
- forces the kernel to write every position, which INIT mode requires;
- fixes `or3s(x %]between[% c(F, T))` for logical x to match the R-level `%]between[%` (which is `or(x <= 0, x >= 1)`, all-TRUE for logical x in {0, 1}). Pre-Phase-2.5 the kernel returned all-FALSE here.

The single test pinning the buggy result (`test-or3s.R:12`) is updated.

## Bench at N=1e9, 10 reps each, separate temp libs

`and3s(x > 5L, x < 100L)` median:

| version | nT=1 | nT=4 |
| --- | --- | --- |
| CRAN 0.10.10 | 0.942s | 0.534s |
| master 0.10.12 (Phase 1+2+3) | 0.985s | 0.632s (**+18% regression**) |
| **phase 2.5 (this PR)** | **0.913s (-3% vs CRAN)** | **0.487s (-9% vs CRAN)** |

Every call shape tested is at-or-faster-than CRAN at both nT=1 and nT=4:

| call | nT=1 Δ | nT=4 Δ |
| --- | --- | --- |
| `and3s(x > 5, x < 100)` | -3% | -8.5% |
| `and3s(x > 5, x %between% c(1,100))` | -0.2% | -7.9% |
| `or3s(x < 0, x > 99)` | -4.3% | -7.3% |
| `and3s(x > 5)` | -4.1% | -12.1% |
| `sum_and3s(x > 5, x < 100)` | -8.5% | +0.8% |
| `and3s(x != 0, x %in% c(1,5,10))` | -6.8% | -6.1% |
| `and3s(xna > 5, xna < 100)` | +4.0% | -8.9% |

The small additional win vs CRAN comes from skipping the entry memset entirely. Pre-Phase-2 also did a sort of memset; the new code does neither.

## Test plan

- [x] Full tinytest suite: 34303/34303 pass.
- [x] LL OP_BC math fix verified: `or3s(x %]between[% c(F, T))` returns all-TRUE; updated `test-or3s.R:12` accordingly.
- [x] Bench vs CRAN at N=1e9, nT=1 / nT=4 -- regression eliminated (above).
- [ ] CI on each platform.

## Sequencing with #53 (Phase 4)

This PR is independent of #53 and can land in either order. If this lands first, #53 inherits the recovered perf. If #53 lands first, this PR rebases trivially (no overlapping files at the kernel/wrapper layer).